### PR TITLE
Fix typo in French translations

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -57,7 +57,7 @@ msgstr "Votre compte a été impliqué dans %s failles de sécurité !"
 
 #: src/Widgets/AccountRow.vala:62
 msgid "Congratulations, you were carefully enough !"
-msgstr "Félécitations, vous avez été assez prudent !"
+msgstr "Félicitations, vous avez été assez prudent !"
 
 #: src/Widgets/HeaderRow.vala:31
 msgid ""


### PR DESCRIPTION
I apologize for this pull request, but I just noticed there was a misspelted word 👎 